### PR TITLE
FlipFlap: allow using HighTouchSensitivity on cover

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -36,6 +36,8 @@
     <string name="category_behaviour">Behaviour</string>
     <string name="pass_to_security_view_title">Directly go to password entry</string>
     <string name="pass_to_security_view_summary">Opening the case directly shows lock screen</string>
+    <string name="use_high_touch_sensitivity_title">High touch sensitivity</string>
+    <string name="use_high_touch_sensitivity_summary">Increse touch sensitivity while cover is closed</string>
 
     <string name="category_design">Design</string>
     <string name="switch_charging_status_title">Show charging status</string>

--- a/res/xml/flipflapsettings_panel.xml
+++ b/res/xml/flipflapsettings_panel.xml
@@ -28,6 +28,12 @@
             android:defaultValue="false"
             android:title="@string/pass_to_security_view_title"
             android:summary="@string/pass_to_security_view_summary" />
+
+        <SwitchPreference
+            android:key="use_high_touch_sensitivity"
+            android:defaultValue="false"
+            android:title="@string/use_high_touch_sensitivity_title"
+            android:summary="@string/use_high_touch_sensitivity_summary" />
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/src/org/lineageos/flipflap/FlipFlapSettingsFragment.java
+++ b/src/org/lineageos/flipflap/FlipFlapSettingsFragment.java
@@ -44,6 +44,7 @@ public class FlipFlapSettingsFragment extends PreferenceFragment
     public final String TAG = "FlipFlapSettings";
 
     private final String KEY_DESIGN_CATEGORY = "category_design";
+    private final String KEY_TOUCH_SENSITIVITY = "use_high_touch_sensitivity";
 
     private Switch mSwitch;
 
@@ -83,9 +84,12 @@ public class FlipFlapSettingsFragment extends PreferenceFragment
         setupTimeoutPreference(FlipFlapUtils.KEY_TIMEOUT_UNPLUGGED);
 
         int cover = FlipFlapUtils.getCoverStyle(getActivity());
+        PreferenceScreen ps = getPreferenceScreen();
         if (!FlipFlapUtils.showsChargingStatus(cover)) {
-            PreferenceScreen ps = getPreferenceScreen();
             ps.removePreference(ps.findPreference(KEY_DESIGN_CATEGORY));
+        }
+        if (!FlipFlapUtils.getHighTouchSensitivitySupported(getContext())) {
+            ps.removePreference(ps.findPreference(KEY_TOUCH_SENSITIVITY));
         }
     }
 

--- a/src/org/lineageos/flipflap/FlipFlapUtils.java
+++ b/src/org/lineageos/flipflap/FlipFlapUtils.java
@@ -26,6 +26,8 @@ import android.preference.PreferenceManager;
 
 import com.android.internal.util.ArrayUtils;
 
+import cyanogenmod.hardware.CMHardwareManager;
+
 public class FlipFlapUtils {
 
     static final String OUR_PACKAGE_NAME = "org.lineageos.flipflap";
@@ -82,4 +84,10 @@ public class FlipFlapUtils {
     public static SharedPreferences getPreferences(Context context) {
         return PreferenceManager.getDefaultSharedPreferences(context);
     }
+
+    public static boolean getHighTouchSensitivitySupported(Context context) {
+        final CMHardwareManager hardware = CMHardwareManager.getInstance(context);
+        return hardware.isSupported(CMHardwareManager.FEATURE_HIGH_TOUCH_SENSITIVITY);
+    }
+
 }

--- a/src/org/lineageos/flipflap/FlipFlapView.java
+++ b/src/org/lineageos/flipflap/FlipFlapView.java
@@ -55,10 +55,12 @@ import java.util.Comparator;
 import java.util.List;
 
 import org.cyanogenmod.internal.util.CmLockPatternUtils;
+import cyanogenmod.providers.CMSettings;
 
 public class FlipFlapView extends FrameLayout {
     private static final String TAG = "FlipFlapView";
     private static final String KEY_PASS_TO_SECURITY = "pass_to_security_view";
+    private static final String KEY_TOUCH_SENSITIVITY = "use_high_touch_sensitivity";
 
     private static final int COVER_CLOSED_MSG = 0;
     private static final int RESTORE_SECURITY_VIEW_STATE = 1;
@@ -75,6 +77,8 @@ public class FlipFlapView extends FrameLayout {
     private boolean mProximityNear;
     private boolean mNotificationListenerRegistered;
     private boolean mPassToSecurity;
+
+    private int mUserHighTouchState;
 
     /* Required to only read the setting when it's already restored, else when closing the cover
     within the timeout (1.5s), it would read "true" (because we set it) and always restore that */
@@ -99,6 +103,7 @@ public class FlipFlapView extends FrameLayout {
         mWakeLock.setReferenceCounted(false);
 
         changeSecurityViewState();
+        checkHighTouchSensitivity();
     }
 
     protected boolean canUseProximitySensor() {
@@ -198,6 +203,7 @@ public class FlipFlapView extends FrameLayout {
         mHandler.removeCallbacksAndMessages(null);
         getContext().unregisterReceiver(mReceiver);
         restoreSecurityViewState();
+        restoreHighTouchSensitivity();
 
         if (supportsNotifications()) {
             try {
@@ -411,6 +417,28 @@ public class FlipFlapView extends FrameLayout {
     private void setPassToSecurityView(boolean enabled) {
         CmLockPatternUtils cml = new CmLockPatternUtils(mContext);
         cml.setPassToSecurityView(enabled, getUserId());
+    }
+
+    private void checkHighTouchSensitivity() {
+        if (shouldUseHighTouchSensitivity() &&
+                FlipFlapUtils.getHighTouchSensitivitySupported(getContext())) {
+            mUserHighTouchState = CMSettings.System.getInt(mContext.getContentResolver(),
+                    CMSettings.System.HIGH_TOUCH_SENSITIVITY_ENABLE, 0);
+            CMSettings.System.putInt(mContext.getContentResolver(),
+                    CMSettings.System.HIGH_TOUCH_SENSITIVITY_ENABLE, 1);
+        }
+    }
+
+    private void restoreHighTouchSensitivity() {
+        if (shouldUseHighTouchSensitivity() &&
+                FlipFlapUtils.getHighTouchSensitivitySupported(getContext())) {
+            CMSettings.System.putInt(mContext.getContentResolver(),
+                    CMSettings.System.HIGH_TOUCH_SENSITIVITY_ENABLE, mUserHighTouchState);
+        }
+    }
+
+    private boolean shouldUseHighTouchSensitivity() {
+        return FlipFlapUtils.getPreferences(mContext).getBoolean(KEY_TOUCH_SENSITIVITY, false);
     }
 
     private int getUserId() {


### PR DESCRIPTION
Some flip covers have plastic/glass insters and are some touches are
missed. Allow users to enable High Touch Sensitivity (glove mode)
specifically for cover. Save and restore users standard glove mode
setting for normal android mode.

Change-Id: Ieee5ad73dc25a3980244af73f5f1037e5b05f398